### PR TITLE
Remove compressed templates

### DIFF
--- a/lib/gakubuchi/task.rb
+++ b/lib/gakubuchi/task.rb
@@ -14,7 +14,7 @@ module Gakubuchi
         dest = template.destination_path
         FileUtils.copy_p(src, dest)
 
-        FileUtils.remove(src) unless leave_digest_named_templates?
+        FileUtils.remove([src, *::Dir.glob("#{src}.gz")]) unless leave_digest_named_templates?
       end
     end
 


### PR DESCRIPTION
I noticed gakubuchi v1.x didn't remove compressed templates (`.html.gz`) even though `leave_digest_named_templates` was set to `true`.
The following is an example of log.

```
I, [2016-01-26T14:31:18.216332 #22773]  INFO -- : Writing /home/travis/build/yasaichi/gakubuchi/spec/dummy/public/assets/foo-6d90791bff065379dd81272338accd06607b6e9ab80b0ba8bace33db155db6cb.html
I, [2016-01-26T14:31:18.216634 #22773]  INFO -- : Writing /home/travis/build/yasaichi/gakubuchi/spec/dummy/public/assets/foo-6d90791bff065379dd81272338accd06607b6e9ab80b0ba8bace33db155db6cb.html.gz
```

```
I, [2016-01-26T14:31:18.269796 #22773]  INFO -- : Copied /home/travis/build/yasaichi/gakubuchi/spec/dummy/public/assets/foo-6d90791bff065379dd81272338accd06607b6e9ab80b0ba8bace33db155db6cb.html to /home/travis/build/yasaichi/gakubuchi/spec/dummy/public/foo.html
I, [2016-01-26T14:31:18.270094 #22773]  INFO -- : Removed /home/travis/build/yasaichi/gakubuchi/spec/dummy/public/assets/foo-6d90791bff065379dd81272338accd06607b6e9ab80b0ba8bace33db155db6cb.html
```

As far as I looked over the dependencies, I found out this bug was caused by sprockets.
From v3.5.0, it generates gzip files for all non-binary assets ([ref](https://github.com/rails/sprockets/blob/3.x/CHANGELOG.md)).
Therefore `.html.gz` is generated, but not removed by gakubuchi.

This PR fixes the bug.