### PR TITLE
Fix error raised when `rails s` is executed without Haml

### DIFF
--- a/lib/gakubuchi/engine_registrar.rb
+++ b/lib/gakubuchi/engine_registrar.rb
@@ -20,7 +20,7 @@ module Gakubuchi
 
     def constantize(klass)
       klass.to_s.constantize
-    rescue ::NameError
+    rescue ::LoadError, ::NameError
       nil
     end
   end


### PR DESCRIPTION
This PR fixes #4.

The error reported in the issue is raised when `rails s` is executed without `Haml`.
The backtrace is as follows (with Rails 4.2.6 and gakubuchi 1.2.1):

```
/path/to/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.6/lib/active_support/dependencies.rb:274:in `require': cannot load such file -- haml (LoadError)
        from /path/to/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.6/lib/active_support/dependencies.rb:274:in `block in require'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.6/lib/active_support/dependencies.rb:240:in `load_dependency'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.6/lib/active_support/dependencies.rb:274:in `require'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/tilt-2.0.2/lib/tilt/haml.rb:2:in `<top (required)>'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.6/lib/active_support/inflector/methods.rb:263:in `const_get'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.6/lib/active_support/inflector/methods.rb:263:in `block in constantize'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.6/lib/active_support/inflector/methods.rb:259:in `each'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.6/lib/active_support/inflector/methods.rb:259:in `inject'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.6/lib/active_support/inflector/methods.rb:259:in `constantize'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.6/lib/active_support/core_ext/string/inflections.rb:66:in `constantize'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/gakubuchi-1.2.1/lib/gakubuchi/engine_registrar.rb:22:in `constantize'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/gakubuchi-1.2.1/lib/gakubuchi/engine_registrar.rb:8:in `register'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/gakubuchi-1.2.1/lib/gakubuchi/railtie.rb:6:in `block in <class:Railtie>'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/sprockets-rails-3.0.4/lib/sprockets/railtie.rb:144:in `call'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/sprockets-rails-3.0.4/lib/sprockets/railtie.rb:144:in `block in build_environment'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/sprockets-rails-3.0.4/lib/sprockets/railtie.rb:143:in `each'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/sprockets-rails-3.0.4/lib/sprockets/railtie.rb:143:in `build_environment'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/railties-4.2.6/lib/rails/railtie.rb:194:in `public_send'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/railties-4.2.6/lib/rails/railtie.rb:194:in `method_missing'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/sprockets-rails-3.0.4/lib/sprockets/railtie.rb:173:in `block in <class:Railtie>'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.6/lib/active_support/lazy_load_hooks.rb:36:in `call'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.6/lib/active_support/lazy_load_hooks.rb:36:in `execute_hook'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.6/lib/active_support/lazy_load_hooks.rb:45:in `block in run_load_hooks'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.6/lib/active_support/lazy_load_hooks.rb:44:in `each'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.6/lib/active_support/lazy_load_hooks.rb:44:in `run_load_hooks'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/railties-4.2.6/lib/rails/application/finisher.rb:62:in `block in <module:Finisher>'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/railties-4.2.6/lib/rails/initializable.rb:30:in `instance_exec'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/railties-4.2.6/lib/rails/initializable.rb:30:in `run'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/railties-4.2.6/lib/rails/initializable.rb:55:in `block in run_initializers'
        from /usr/local/var/rbenv/versions/2.2.1/lib/ruby/2.2.0/tsort.rb:226:in `block in tsort_each'
        from /usr/local/var/rbenv/versions/2.2.1/lib/ruby/2.2.0/tsort.rb:348:in `block (2 levels) in each_strongly_connected_component'
        from /usr/local/var/rbenv/versions/2.2.1/lib/ruby/2.2.0/tsort.rb:429:in `each_strongly_connected_component_from'
        from /usr/local/var/rbenv/versions/2.2.1/lib/ruby/2.2.0/tsort.rb:347:in `block in each_strongly_connected_component'
        from /usr/local/var/rbenv/versions/2.2.1/lib/ruby/2.2.0/tsort.rb:345:in `each'
        from /usr/local/var/rbenv/versions/2.2.1/lib/ruby/2.2.0/tsort.rb:345:in `call'
        from /usr/local/var/rbenv/versions/2.2.1/lib/ruby/2.2.0/tsort.rb:345:in `each_strongly_connected_component'
        from /usr/local/var/rbenv/versions/2.2.1/lib/ruby/2.2.0/tsort.rb:224:in `tsort_each'
        from /usr/local/var/rbenv/versions/2.2.1/lib/ruby/2.2.0/tsort.rb:203:in `tsort_each'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/railties-4.2.6/lib/rails/initializable.rb:54:in `run_initializers'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/railties-4.2.6/lib/rails/application.rb:352:in `initialize!'
        from /path/to/test_app/config/environment.rb:5:in `<top (required)>'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/railties-4.2.6/lib/rails/application.rb:328:in `require'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/railties-4.2.6/lib/rails/application.rb:328:in `require_environment!'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/railties-4.2.6/lib/rails/commands/commands_tasks.rb:142:in `require_application_and_environment!'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/railties-4.2.6/lib/rails/commands/commands_tasks.rb:67:in `console'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/railties-4.2.6/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
        from /path/to/vendor/bundle/ruby/2.2.0/gems/railties-4.2.6/lib/rails/commands.rb:17:in `<top (required)>'
        from bin/rails:4:in `require'
        from bin/rails:4:in `<main>'
```

As I described in the issue, we had overlooked it until now because:

1. Rails app depends on `tilt` by default because `sass-rails` depends on it.  
Therefore, we can find `Tilt::HamlTemplate`.
2. `Tilt::HamlTemplate` calls `require 'haml'` [there](https://github.com/rtomayko/tilt/blob/master/lib/tilt/haml.rb#L2) although [Tilt](https://github.com/rtomayko/tilt) doesen't depend on any gems.
3. Gakubuchi's development dependencies include `haml-rails` (which depends on `haml`).

This PR fixes it by rescuing `LoadError` in `EngineRegistrar#constantize`.