### PR TITLE
Follow Rails RuboCop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,9 @@ gemfiles/*.lock
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
 
+# RuboCop cache
+.rubocop-http*
+
 
 ### https://raw.github.com/github/gitignore/47b1ace3d0b71722ea93be14f42846ab3329f161/Global/JetBrains.gitignore
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,13 +1,17 @@
-AllCops:
-  RunRailsCops: true
-  Exclude:
-    - 'gakubuchi.gemspec'
-    - 'spec/rails_helper.rb'
-    - 'spec/spec_helper.rb'
-    - 'spec/dummy/**/*'
+inherit_from:
+  - https://raw.githubusercontent.com/rails/rails/master/.rubocop.yml
 
-Documentation:
-  Enabled: false
+AllCops:
+  Rails:
+    Enabled: true
+  Exclude:
+    - "gakubuchi.gemspec"
+    - "spec/rails_helper.rb"
+    - "spec/spec_helper.rb"
+    - "spec/dummy/**/*"
 
 LineLength:
   Max: 100
+
+Style/IndentationConsistency:
+  EnforcedStyle: normal

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Declare your gem's dependencies in gakubuchi.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and
@@ -11,6 +11,6 @@ gemspec
 # your gem to rubygems.org.
 
 group :development, :test do
-  gem 'pry-byebug'
-  gem 'pry-coolline'
+  gem "pry-byebug"
+  gem "pry-coolline"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,26 +1,26 @@
 begin
-  require 'bundler/setup'
+  require "bundler/setup"
 rescue LoadError
-  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+  puts "You must `gem install bundler` and `bundle install` to run rake tasks"
 end
 
-require 'rdoc/task'
+require "rdoc/task"
 
 RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'Gakubuchi'
-  rdoc.options << '--line-numbers'
-  rdoc.rdoc_files.include('README.rdoc')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+  rdoc.rdoc_dir = "rdoc"
+  rdoc.title    = "Gakubuchi"
+  rdoc.options << "--line-numbers"
+  rdoc.rdoc_files.include("README.rdoc")
+  rdoc.rdoc_files.include("lib/**/*.rb")
 end
 
-APP_RAKEFILE = File.expand_path('../spec/dummy/Rakefile', __FILE__)
-load 'rails/tasks/engine.rake'
+APP_RAKEFILE = File.expand_path("../spec/dummy/Rakefile", __FILE__)
+load "rails/tasks/engine.rake"
 
-load 'rails/tasks/statistics.rake'
+load "rails/tasks/statistics.rake"
 
 Bundler::GemHelper.install_tasks
 
-require 'rspec/core/rake_task'
+require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 task default: :spec

--- a/lib/gakubuchi.rb
+++ b/lib/gakubuchi.rb
@@ -1,19 +1,19 @@
-require 'fileutils'
-require 'forwardable'
-require 'logger'
-require 'active_support/configurable'
+require "fileutils"
+require "forwardable"
+require "logger"
+require "active_support/configurable"
 
-require 'gakubuchi/configuration'
-require 'gakubuchi/error'
-require 'gakubuchi/fileutils'
-require 'gakubuchi/task'
-require 'gakubuchi/version'
+require "gakubuchi/configuration"
+require "gakubuchi/error"
+require "gakubuchi/fileutils"
+require "gakubuchi/task"
+require "gakubuchi/version"
 
 if defined?(::Rails::Railtie) && defined?(::Sprockets::Railtie)
-  require 'pathname'
-  require 'gakubuchi/engine_registrar'
-  require 'gakubuchi/template'
-  require 'gakubuchi/railtie'
+  require "pathname"
+  require "gakubuchi/engine_registrar"
+  require "gakubuchi/template"
+  require "gakubuchi/railtie"
 end
 
 module Gakubuchi

--- a/lib/gakubuchi/configuration.rb
+++ b/lib/gakubuchi/configuration.rb
@@ -11,7 +11,7 @@ module Gakubuchi
     end
 
     config_accessor :template_directory do
-      'templates'
+      "templates"
     end
   end
 end

--- a/lib/gakubuchi/railtie.rb
+++ b/lib/gakubuchi/railtie.rb
@@ -3,12 +3,12 @@ module Gakubuchi
     config.assets.configure do |env|
       engine_registrar = EngineRegistrar.new(env)
 
-      engine_registrar.register(:haml, '::Tilt::HamlTemplate')
-      engine_registrar.register(:slim, '::Slim::Template')
+      engine_registrar.register(:haml, "::Tilt::HamlTemplate")
+      engine_registrar.register(:slim, "::Slim::Template")
     end
 
     rake_tasks do
-      ::Dir.glob(::File.expand_path('../../tasks/*.rake', __FILE__)).each { |path| load path }
+      ::Dir.glob(::File.expand_path("../../tasks/*.rake", __FILE__)).each { |path| load path }
     end
   end
 end

--- a/lib/gakubuchi/template.rb
+++ b/lib/gakubuchi/template.rb
@@ -12,11 +12,11 @@ module Gakubuchi
     end
 
     def self.all
-      ::Dir.glob(root.join('**/*.html*')).map { |source_path| new(source_path) }
+      ::Dir.glob(root.join("**/*.html*")).map { |source_path| new(source_path) }
     end
 
     def self.root
-      ::Rails.root.join('app/assets', ::Gakubuchi.configuration.template_directory)
+      ::Rails.root.join("app/assets", ::Gakubuchi.configuration.template_directory)
     end
 
     def initialize(source_path)
@@ -27,9 +27,9 @@ module Gakubuchi
       @source_path = path.absolute? ? path : root.join(path)
 
       case
-      when !@extname.include?('html')
-        fail Error::InvalidTemplate, 'source path must refer to a template file'
-      when !@source_path.fnmatch?(root.join('*').to_s)
+      when !@extname.include?("html")
+        fail Error::InvalidTemplate, "source path must refer to a template file"
+      when !@source_path.fnmatch?(root.join("*").to_s)
         fail Error::InvalidTemplate, "template must exist in #{root}"
       end
     end

--- a/lib/gakubuchi/version.rb
+++ b/lib/gakubuchi/version.rb
@@ -1,3 +1,3 @@
 module Gakubuchi
-  VERSION = "1.2.2"
+  VERSION = "1.2.2".freeze
 end

--- a/lib/gakubuchi/version.rb
+++ b/lib/gakubuchi/version.rb
@@ -1,3 +1,3 @@
 module Gakubuchi
-  VERSION = '1.2.2'
+  VERSION = "1.2.2"
 end

--- a/lib/generators/gakubuchi/install/install_generator.rb
+++ b/lib/generators/gakubuchi/install/install_generator.rb
@@ -3,21 +3,21 @@ module Gakubuchi
     class InstallGenerator < ::Rails::Generators::Base
       DEFAULT_DIRECTORY = ::Gakubuchi::Configuration.new.template_directory.freeze
 
-      desc 'Create a Gakubuchi initializer.'
-      source_root ::File.expand_path('../templates', __FILE__)
+      desc "Create a Gakubuchi initializer."
+      source_root ::File.expand_path("../templates", __FILE__)
 
       class_option :directory,
         type: :string,
-        aliases: '-d',
+        aliases: "-d",
         default: DEFAULT_DIRECTORY,
-        desc: 'Name of directory for templates'
+        desc: "Name of directory for templates"
 
       def copy_initializer_file
-        template 'gakubuchi.rb.erb', 'config/initializers/gakubuchi.rb'
+        template "gakubuchi.rb.erb", "config/initializers/gakubuchi.rb"
       end
 
       def create_template_directory
-        empty_directory ::Pathname.new('app/assets').join(options.directory)
+        empty_directory ::Pathname.new("app/assets").join(options.directory)
       end
     end
   end

--- a/lib/tasks/after_precompile.rake
+++ b/lib/tasks/after_precompile.rake
@@ -1,4 +1,4 @@
-Rake::Task['assets:precompile'].enhance do
+Rake::Task["assets:precompile"].enhance do
   task = Gakubuchi::Task.new(Gakubuchi::Template.all)
   task.execute!
 end

--- a/spec/lib/gakubuchi/configuration_spec.rb
+++ b/spec/lib/gakubuchi/configuration_spec.rb
@@ -1,17 +1,17 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Gakubuchi::Configuration do
   let(:configuration) { described_class.new }
 
-  describe '#to_h' do
+  describe "#to_h" do
     subject { configuration.to_h }
     it { is_expected.to be_an_instance_of Hash }
   end
 
-  describe '#leave_digest_named_templates' do
+  describe "#leave_digest_named_templates" do
     subject { configuration.leave_digest_named_templates }
 
-    context 'when a value was set by the attr_writer' do
+    context "when a value was set by the attr_writer" do
       before do
         configuration.leave_digest_named_templates = true
       end
@@ -19,24 +19,24 @@ RSpec.describe Gakubuchi::Configuration do
       it { is_expected.to eq true }
     end
 
-    context 'when a value was not set by the attr_writer' do
+    context "when a value was not set by the attr_writer" do
       it { is_expected.to eq false }
     end
   end
 
-  describe '#template_directory' do
+  describe "#template_directory" do
     subject { configuration.template_directory }
 
-    context 'when a value was set by the attr_writer' do
+    context "when a value was set by the attr_writer" do
       before do
-        configuration.template_directory = 'foo'
+        configuration.template_directory = "foo"
       end
 
-      it { is_expected.to eq 'foo' }
+      it { is_expected.to eq "foo" }
     end
 
-    context 'when a value was not set by the attr_writer' do
-      it { is_expected.to eq 'templates' }
+    context "when a value was not set by the attr_writer" do
+      it { is_expected.to eq "templates" }
     end
   end
 end

--- a/spec/lib/gakubuchi/engine_registrar_spec.rb
+++ b/spec/lib/gakubuchi/engine_registrar_spec.rb
@@ -1,69 +1,69 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Gakubuchi::EngineRegistrar do
   let(:env) { Sprockets::Environment.new }
   let(:engine_registrar) { described_class.new(env) }
 
-  describe '#register' do
+  describe "#register" do
     let(:described_method) { -> { engine_registrar.register(target, engine) } }
 
-    context 'when specified engine is an uninitialized constant' do
+    context "when specified engine is an uninitialized constant" do
       let(:target) { :foo }
-      let(:engine) { 'Foo' }
+      let(:engine) { "Foo" }
 
-      describe 'env.engines' do
+      describe "env.engines" do
         subject { -> { env.engines } }
         it { expect(&described_method).not_to change(&subject) }
       end
 
-      describe 'return value' do
+      describe "return value" do
         subject { described_method.call }
         it { is_expected.to eq false }
       end
     end
 
-    context 'when specified target is already registered' do
+    context "when specified target is already registered" do
       let(:target) { :coffee }
-      let(:engine) { 'Sprockets::ERBProcessor' }
+      let(:engine) { "Sprockets::ERBProcessor" }
 
-      describe 'env.engines' do
+      describe "env.engines" do
         subject { -> { env.engines } }
         it { expect(&described_method).not_to change(&subject) }
       end
 
-      describe 'return value' do
+      describe "return value" do
         subject { described_method.call }
         it { is_expected.to eq false }
       end
     end
 
-    context 'when specified target is not registered' do
+    context "when specified target is not registered" do
       let(:target) { :foo }
-      let(:engine) { 'Sprockets::ERBProcessor' }
+      let(:engine) { "Sprockets::ERBProcessor" }
 
-      describe 'env.engines' do
+      describe "env.engines" do
         subject { -> { env.engines } }
-        let(:expectation) { a_hash_including('.foo' => Sprockets::ERBProcessor) }
+        let(:expectation) { a_hash_including(".foo" => Sprockets::ERBProcessor) }
 
         it { expect(&described_method).to change(&subject).to(expectation) }
       end
 
-      describe 'return value' do
+      describe "return value" do
         subject { described_method.call }
         it { is_expected.to eq true }
       end
     end
   end
 
-  describe '#registered?' do
+  describe "#registered?" do
     subject { engine_registrar.registered?(target) }
 
-    context 'when specified target is not registered' do
+    context "when specified target is not registered" do
       let(:target) { :foo }
       it { is_expected.to eq false }
     end
 
-    context 'when specified target is already registered' do
+    context "when specified target is already registered" do
       let(:target) { :erb }
       it { is_expected.to eq true }
     end

--- a/spec/lib/gakubuchi/task_spec.rb
+++ b/spec/lib/gakubuchi/task_spec.rb
@@ -1,13 +1,13 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Gakubuchi::Task do
   let(:task) { described_class.new(templates) }
 
-  describe '#execute!' do
+  describe "#execute!" do
     let(:templates) { [template] }
     let(:template) { Gakubuchi::Template.new(source_path) }
 
-    describe 'Gakubuchi::FileUtils' do
+    describe "Gakubuchi::FileUtils" do
       subject { Gakubuchi::FileUtils }
 
       before do
@@ -15,26 +15,26 @@ RSpec.describe Gakubuchi::Task do
         allow(subject).to receive(:remove)
       end
 
-      context 'when template does not exist in specified source path' do
-        let(:source_path) { 'not_exist.html.erb' }
+      context "when template does not exist in specified source path" do
+        let(:source_path) { "not_exist.html.erb" }
 
         before do
           task.execute!
         end
 
-        describe '.copy_p' do
+        describe ".copy_p" do
           it { is_expected.not_to have_received(:copy_p) }
         end
 
-        describe '.remove' do
+        describe ".remove" do
           it { is_expected.not_to have_received(:remove) }
         end
       end
 
-      context 'when template exists in specified source path' do
-        let(:source_path) { 'foo.html.erb' }
+      context "when template exists in specified source path" do
+        let(:source_path) { "foo.html.erb" }
 
-        describe '.copy_p' do
+        describe ".copy_p" do
           let(:expectation) { [template.digest_path, template.destination_path] }
 
           before do
@@ -44,18 +44,18 @@ RSpec.describe Gakubuchi::Task do
           it { is_expected.to have_received(:copy_p).with(*expectation) }
         end
 
-        describe '.remove' do
+        describe ".remove" do
           before do
             allow(task).to receive(:leave_digest_named_templates?).and_return(return_value)
             task.execute!
           end
 
-          context 'when #leave_digest_named_templates? returns true' do
+          context "when #leave_digest_named_templates? returns true" do
             let(:return_value) { true }
             it { is_expected.not_to have_received(:remove) }
           end
 
-          context 'when #leave_digest_named_templates? returns false' do
+          context "when #leave_digest_named_templates? returns false" do
             let(:return_value) { false }
             let(:expectation) { a_collection_including(template.digest_path) }
 
@@ -66,7 +66,7 @@ RSpec.describe Gakubuchi::Task do
     end
   end
 
-  describe '#leave_digest_named_templates?' do
+  describe "#leave_digest_named_templates?" do
     subject { task.leave_digest_named_templates? }
     let(:templates) { [] }
 
@@ -74,12 +74,12 @@ RSpec.describe Gakubuchi::Task do
       Gakubuchi.configuration.leave_digest_named_templates = config_value
     end
 
-    context 'when the configuration value is evaluated as true' do
+    context "when the configuration value is evaluated as true" do
       let(:config_value) { 1 }
       it { is_expected.to eq true }
     end
 
-    context 'when the configuration value is evaluated as false' do
+    context "when the configuration value is evaluated as false" do
       let(:config_value) { nil }
       it { is_expected.to eq false }
     end

--- a/spec/lib/gakubuchi/template_spec.rb
+++ b/spec/lib/gakubuchi/template_spec.rb
@@ -1,47 +1,47 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Gakubuchi::Template do
   let(:template) { described_class.new(source_path) }
   let(:template_root) { described_class.root }
 
-  describe '.all' do
+  describe ".all" do
     subject { described_class.all }
 
     let(:expectation) do
       [
-        described_class.new('foo.html.erb'),
-        described_class.new('bar/baz.html.erb'),
-        described_class.new('qux.html.haml'),
-        described_class.new('quux.html.slim')
+        described_class.new("foo.html.erb"),
+        described_class.new("bar/baz.html.erb"),
+        described_class.new("qux.html.haml"),
+        described_class.new("quux.html.slim")
       ]
     end
 
     it { is_expected.to match_array(expectation) }
   end
 
-  describe '.new' do
+  describe ".new" do
     subject { -> { described_class.new(source_path) } }
 
-    context 'when source path does not refer to a template file' do
-      let(:source_path) { 'foo.txt' }
-      let(:error_message) { 'source path must refer to a template file' }
+    context "when source path does not refer to a template file" do
+      let(:source_path) { "foo.txt" }
+      let(:error_message) { "source path must refer to a template file" }
 
       it { is_expected.to raise_error(Gakubuchi::Error::InvalidTemplate, error_message) }
     end
 
-    context 'when source path refers to a template file' do
-      context 'when tha path is relative' do
-        let(:source_path) { 'foo.html.erb' }
+    context "when source path refers to a template file" do
+      context "when tha path is relative" do
+        let(:source_path) { "foo.html.erb" }
         it { is_expected.not_to raise_error }
       end
 
       context "when the path is absolute and begins with #{described_class}.root" do
-        let(:source_path) { template_root.join('foo.html.erb') }
+        let(:source_path) { template_root.join("foo.html.erb") }
         it { is_expected.not_to raise_error }
       end
 
       context "when the path is absolute but does not begin with #{described_class}.root" do
-        let(:source_path) { '/foo.html.erb' }
+        let(:source_path) { "/foo.html.erb" }
         let(:error_message) { "template must exist in #{described_class.root}" }
 
         it { is_expected.to raise_error(Gakubuchi::Error::InvalidTemplate, error_message) }
@@ -49,85 +49,85 @@ RSpec.describe Gakubuchi::Template do
     end
   end
 
-  describe '.root' do
+  describe ".root" do
     subject { described_class.root }
-    it { is_expected.to eq Rails.root.join('app/assets', Gakubuchi.configuration.template_directory) }
+    it { is_expected.to eq Rails.root.join("app/assets", Gakubuchi.configuration.template_directory) }
   end
 
   %w(== === eql?).each do |method_name|
     describe "##{method_name}" do
       subject { template.__send__(method_name, other) }
-      let(:source_path) { 'foo.html.erb' }
+      let(:source_path) { "foo.html.erb" }
 
-      context 'when other is not an instance of Gakubuchi::Template' do
+      context "when other is not an instance of Gakubuchi::Template" do
         let(:other) { source_path }
         it { is_expected.to eq false }
       end
 
-      context 'when other is an instance of Gakubuchi::Template' do
+      context "when other is an instance of Gakubuchi::Template" do
         let(:other) { described_class.new(other_source_path) }
 
-        context 'when #source_path is equal to other.source_path' do
+        context "when #source_path is equal to other.source_path" do
           let(:other_source_path) { source_path }
           it { is_expected.to eq true }
         end
 
-        context 'when #source_path is not equal to other.source_path' do
-          let(:other_source_path) { 'bar/baz.html.erb' }
+        context "when #source_path is not equal to other.source_path" do
+          let(:other_source_path) { "bar/baz.html.erb" }
           it { is_expected.to eq false }
         end
       end
     end
   end
 
-  describe '#destination_path' do
+  describe "#destination_path" do
     subject { template.destination_path }
-    let(:source_path) { 'bar/baz.html.erb' }
+    let(:source_path) { "bar/baz.html.erb" }
 
-    it { is_expected.to eq Rails.public_path.join('bar/baz.html') }
+    it { is_expected.to eq Rails.public_path.join("bar/baz.html") }
   end
 
-  describe '#digest_path' do
+  describe "#digest_path" do
     subject { template.digest_path }
 
-    context 'when template does not exist in specified source path' do
-      let(:source_path) { 'not_exist.html.erb' }
+    context "when template does not exist in specified source path" do
+      let(:source_path) { "not_exist.html.erb" }
       it { is_expected.to eq nil }
     end
 
-    context 'when template exists in specified source path' do
-      let(:source_path) { 'bar/baz.html.erb' }
-      let(:expectation) { Rails.public_path.join('assets', 'bar/baz-[a-z0-9]*.html').to_s }
+    context "when template exists in specified source path" do
+      let(:source_path) { "bar/baz.html.erb" }
+      let(:expectation) { Rails.public_path.join("assets", "bar/baz-[a-z0-9]*.html").to_s }
 
       it { is_expected.to be_an_instance_of Pathname }
       it { is_expected.to be_fnmatch(expectation) }
     end
   end
 
-  describe '#extnanme' do
+  describe "#extnanme" do
     subject { template.extname }
-    let(:source_path) { 'foo.html.erb' }
+    let(:source_path) { "foo.html.erb" }
 
-    it { is_expected.to eq '.html.erb' }
+    it { is_expected.to eq ".html.erb" }
   end
 
-  describe '#logical_path' do
+  describe "#logical_path" do
     subject { template.logical_path }
-    let(:source_path) { 'bar/baz.html.erb' }
+    let(:source_path) { "bar/baz.html.erb" }
 
-    it { is_expected.to eq Pathname.new('bar/baz.html') }
+    it { is_expected.to eq Pathname.new("bar/baz.html") }
   end
 
-  describe '#source_path' do
+  describe "#source_path" do
     subject { template.source_path }
 
-    context 'when specified source path is relative' do
-      let(:source_path) { 'foo.html.erb' }
+    context "when specified source path is relative" do
+      let(:source_path) { "foo.html.erb" }
       it { is_expected.to eq template_root.join(source_path) }
     end
 
-    context 'when specified source path is absolute' do
-      let(:source_path) { template_root.join('foo.html.erb') }
+    context "when specified source path is absolute" do
+      let(:source_path) { template_root.join("foo.html.erb") }
       it { is_expected.to eq source_path }
     end
   end

--- a/spec/lib/gakubuchi_spec.rb
+++ b/spec/lib/gakubuchi_spec.rb
@@ -1,18 +1,18 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Gakubuchi do
-  describe '.configuration' do
+  describe ".configuration" do
     subject { described_class.configuration }
     it { is_expected.to be_an_instance_of Gakubuchi::Configuration }
   end
 
-  describe '.configure' do
+  describe ".configure" do
     subject { described_class.configuration }
 
     let(:expected_attrs) do
       {
         leave_digest_named_templates: true,
-        template_directory: 'foo'
+        template_directory: "foo"
       }
     end
 

--- a/spec/lib/generators/gakubuchi/install/install_generator_spec.rb
+++ b/spec/lib/generators/gakubuchi/install/install_generator_spec.rb
@@ -1,21 +1,21 @@
-require 'rails_helper'
-require 'ammeter/init'
-require 'generators/gakubuchi/install/install_generator'
+require "rails_helper"
+require "ammeter/init"
+require "generators/gakubuchi/install/install_generator"
 
 RSpec.describe Gakubuchi::Generators::InstallGenerator, type: :generator do
-  destination File.expand_path('../tmp', __FILE__)
+  destination File.expand_path("../tmp", __FILE__)
 
   before do
     prepare_destination
   end
 
-  describe 'generated files' do
+  describe "generated files" do
     before do
       run_generator(args)
     end
 
-    describe 'config/initializers/gakubuchi.rb' do
-      subject { file('config/initializers/gakubuchi.rb') }
+    describe "config/initializers/gakubuchi.rb" do
+      subject { file("config/initializers/gakubuchi.rb") }
 
       let(:expected_content) do
         /\A
@@ -29,7 +29,7 @@ RSpec.describe Gakubuchi::Generators::InstallGenerator, type: :generator do
         \Z/mx
       end
 
-      context 'when directory is not specified' do
+      context "when directory is not specified" do
         let(:args) { [] }
         let(:expected_configuration) { %q(\#\ config.template_directory\ =\ 'templates') }
 
@@ -38,7 +38,7 @@ RSpec.describe Gakubuchi::Generators::InstallGenerator, type: :generator do
         it { is_expected.to contain expected_content }
       end
 
-      context 'when directory is specified' do
+      context "when directory is specified" do
         let(:args) { %w(--directory=foo) }
         let(:expected_configuration) { %q(config.template_directory\ =\ 'foo') }
 

--- a/spec/lib/tasks/after_precompile_spec.rb
+++ b/spec/lib/tasks/after_precompile_spec.rb
@@ -1,35 +1,35 @@
-require 'rails_helper'
+require "rails_helper"
 
-describe 'rake assets:precompile' do
+describe "rake assets:precompile" do
   before(:context) do
     Rails.application.load_tasks
   end
 
-  describe 'precompiled templates' do
-    subject { Pathname.glob(Rails.public_path.join('**/*.html')) }
+  describe "precompiled templates" do
+    subject { Pathname.glob(Rails.public_path.join("**/*.html")) }
 
     let(:expectation) do
       [
-        Rails.public_path.join('foo.html'),
-        Rails.public_path.join('bar/baz.html'),
-        Rails.public_path.join('qux.html'),
-        Rails.public_path.join('quux.html')
+        Rails.public_path.join("foo.html"),
+        Rails.public_path.join("bar/baz.html"),
+        Rails.public_path.join("qux.html"),
+        Rails.public_path.join("quux.html")
       ]
     end
 
     before do
-      Rake::Task['assets:precompile'].execute
+      Rake::Task["assets:precompile"].execute
     end
 
     it { is_expected.to match_array(expectation) }
   end
 
-  describe 'task' do
+  describe "task" do
     let(:task) { double(:task, execute!: true) }
 
     before do
       allow(Gakubuchi::Task).to receive(:new).and_return(task)
-      Rake::Task['assets:precompile'].execute
+      Rake::Task["assets:precompile"].execute
     end
 
     it { expect(Gakubuchi::Task).to have_received(:new).with(Gakubuchi::Template.all) }
@@ -37,7 +37,7 @@ describe 'rake assets:precompile' do
   end
 
   after do
-    Rake::Task['assets:clobber'].execute
-    FileUtils.rm_r(Dir.glob(Rails.public_path.join('*')), secure: true)
+    Rake::Task["assets:clobber"].execute
+    FileUtils.rm_r(Dir.glob(Rails.public_path.join("*")), secure: true)
   end
 end


### PR DESCRIPTION
# Summary
We should follow RuboCop settings used by Rails because it seems better than the default one.
This PR fixes related files.

# Changes
- `.gitignore`: Ignore RuboCop cache
- `.rubucop.yml`: Follow Rails Rubocop
- the others: Apply `rubocop --auto-correct`

NOTE: I also changed `lib/gakubuchi/version.rb` to freeze the version string.