### PR TITLE
Enable just digest-named templates to show error pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,24 @@ If you want to get the list of all available helpers, please execute the followi
 Sprockets::Rails::Helper.instance_methods
 ```
 
+## Using `Gakubuchi::PublicException`
+
+Gakubuchi provides a special exceptions app as `Gakubuchi::PublicException`
+that allows digest-named templates (like `public/assets/404-*.html.slim`) themselves to show
+error pages.
+
+```ruby
+Rails.application.config.exceptions_app = Gakubuchi::PublicExceptions.new(Rails.public_path)
+```
+
+Using it, `public/404.html` is no longer needed and you can set copy_templates_to_public to false.
+
 ## Configuration
 In `config/initializers/gakubuchi.rb`, you can configure the following values.
 
 ```
 leave_digest_named_templates # false by default
+copy_templates_to_public     # true by default
 template_directory           # 'templates' by default
 ```
 

--- a/lib/gakubuchi.rb
+++ b/lib/gakubuchi.rb
@@ -14,6 +14,7 @@ if defined?(::Rails::Railtie) && defined?(::Sprockets::Railtie)
   require "gakubuchi/engine_registrar"
   require "gakubuchi/template"
   require "gakubuchi/railtie"
+  require "gakubuchi/public_exceptions"
 end
 
 module Gakubuchi

--- a/lib/gakubuchi/configuration.rb
+++ b/lib/gakubuchi/configuration.rb
@@ -10,6 +10,10 @@ module Gakubuchi
       false
     end
 
+    config_accessor :copy_templates_to_public do
+      true
+    end
+
     config_accessor :template_directory do
       "templates"
     end

--- a/lib/gakubuchi/public_exceptions.rb
+++ b/lib/gakubuchi/public_exceptions.rb
@@ -1,0 +1,15 @@
+module Gakubuchi
+  class PublicExceptions < ::ActionDispatch::PublicExceptions
+    def render_html(status)
+      view_context = ::ActionView::Base.new
+      digest_path = view_context.asset_digest_path("#{status}.#{I18n.locale}.html") ||
+                    view_context.asset_digest_path("#{status}.html")
+      if digest_path
+        path = File.join(public_path, view_context.assets_prefix, digest_path)
+        render_format(status, 'text/html', File.read(path))
+      else
+        super
+      end
+    end
+  end
+end

--- a/lib/gakubuchi/task.rb
+++ b/lib/gakubuchi/task.rb
@@ -7,6 +7,7 @@ module Gakubuchi
     end
 
     def execute!
+      return unless copy_templates_to_public?
       templates.each do |template|
         src = template.digest_path
         next if src.nil?
@@ -16,6 +17,10 @@ module Gakubuchi
 
         FileUtils.remove([src, *::Dir.glob("#{src}.gz")]) unless leave_digest_named_templates?
       end
+    end
+
+    def copy_templates_to_public?
+      !!::Gakubuchi.configuration.copy_templates_to_public
     end
 
     def leave_digest_named_templates?

--- a/lib/generators/gakubuchi/install/templates/gakubuchi.rb.erb
+++ b/lib/generators/gakubuchi/install/templates/gakubuchi.rb.erb
@@ -4,6 +4,11 @@ Gakubuchi.configure do |config|
   # the non-digest-named copies in public directory.
   # config.leave_digest_named_templates = false
 
+  # Set this configuration to false if you don't need the non-digest-named
+  # copies in public directory.
+  # Note that if set to false, config.leave_digest_named_templates is ignored.
+  # config.copy_templates_to_public = true
+
   # Name of directory for templates ('<%= DEFAULT_DIRECTORY %>' by default).
   # Gakubuchi treats "app/assets/#{config.template_directory}" as root directory
   # for static pages you want to manage with Asset Pipeline.

--- a/spec/lib/gakubuchi/task_spec.rb
+++ b/spec/lib/gakubuchi/task_spec.rb
@@ -35,13 +35,22 @@ RSpec.describe Gakubuchi::Task do
         let(:source_path) { "foo.html.erb" }
 
         describe ".copy_p" do
-          let(:expectation) { [template.digest_path, template.destination_path] }
-
           before do
+            allow(task).to receive(:copy_templates_to_public?).and_return(return_value)
             task.execute!
           end
 
-          it { is_expected.to have_received(:copy_p).with(*expectation) }
+          context "when #copy_templates_to_public? returns true" do
+            let(:return_value) { true }
+            let(:expectation) { [template.digest_path, template.destination_path] }
+
+            it { is_expected.to have_received(:copy_p).with(*expectation) }
+          end
+
+          context "when #copy_templates_to_public? returns false" do
+            let(:return_value) { false }
+            it { is_expected.not_to have_received(:copy_p) }
+          end
         end
 
         describe ".remove" do


### PR DESCRIPTION
Running assets:precompile sometimes fails with Gakubuchi.
cf. http://docs.komagata.org/5407

I'm doubtful about the rake task after assets:precompile but it is not clear yet.
To avoid running the rake task, I introduce a special exceptions app as Gakubuchi::PublicException that allows digest-named templates (like `public/assets/404-*.html.slim`) themselves to show error pages. I also introduce a configuration option to switch whether to run the task.

This solution can be applied only in the case of error pages, but I think this is still useful.