### PR TITLE
Fix precompile bug when disabling fallback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,19 @@ language: ruby
 sudo: false
 rvm:
   - 2.0
-  - 2.1
-  - 2.2
-  - 2.3.0
+  - 2.1.9
+  - 2.2.5
+  - 2.3.1
 gemfile:
-  - gemfiles/rails40x.gemfile
-  - gemfiles/rails41x.gemfile
-  - gemfiles/rails42x.gemfile
+  - gemfiles/sprockets_rails_2_with_sprockets_2.gemfile
+  - gemfiles/sprockets_rails_2_with_sprockets_3.gemfile
+  - gemfiles/sprockets_rails_3_with_sprockets_3.gemfile
+matrix:
+  exclude:
+    - rvm: 2.0
+      gemfile: gemfiles/sprockets_rails_3_with_sprockets_3.gemfile
+    - rvm: 2.1.9
+      gemfile: gemfiles/sprockets_rails_3_with_sprockets_3.gemfile
 branches:
   only:
     - master

--- a/Appraisals
+++ b/Appraisals
@@ -1,14 +1,16 @@
-appraise 'rails40x' do
-  gem 'railties', '~> 4.0.0'
-  gem 'sprockets-rails', '~> 2.0'
+appraise "sprockets-rails 2 with sprockets 2" do
+  gem "railties", "~> 4.0"
+  gem "sprockets-rails", "~> 2.0"
+  gem "sprockets", "~> 2.0"
 end
 
-appraise 'rails41x' do
-  gem 'railties', '~> 4.1.0'
-  gem 'sprockets-rails', '~> 2.0'
+appraise "sprockets-rails 2 with sprockets 3" do
+  gem "railties", "~> 4.0"
+  gem "sprockets-rails", "~> 2.0"
+  gem "sprockets", "~> 3.0"
 end
 
-appraise 'rails42x' do
-  gem 'railties', '~> 4.2.0'
-  gem 'sprockets-rails', '>= 3.0.0'
+appraise "sprockets-rails 3 with sprockets 3" do
+  gem "sprockets-rails", "~> 3.0"
+  gem "sprockets", "~> 3.0"
 end

--- a/gemfiles/sprockets_rails_2_with_sprockets_2.gemfile
+++ b/gemfiles/sprockets_rails_2_with_sprockets_2.gemfile
@@ -2,8 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "railties", "~> 4.2.0"
-gem "sprockets-rails", ">= 3.0.0"
+gem "railties", "~> 4.0"
+gem "sprockets-rails", "~> 2.0"
+gem "sprockets", "~> 2.0"
 
 group :development, :test do
   gem "pry-byebug"

--- a/gemfiles/sprockets_rails_2_with_sprockets_3.gemfile
+++ b/gemfiles/sprockets_rails_2_with_sprockets_3.gemfile
@@ -2,8 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "railties", "~> 4.1.0"
+gem "railties", "~> 4.0"
 gem "sprockets-rails", "~> 2.0"
+gem "sprockets", "~> 3.0"
 
 group :development, :test do
   gem "pry-byebug"

--- a/gemfiles/sprockets_rails_3_with_sprockets_3.gemfile
+++ b/gemfiles/sprockets_rails_3_with_sprockets_3.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "railties", "~> 4.0.0"
-gem "sprockets-rails", "~> 2.0"
+gem "sprockets-rails", "~> 3.0"
+gem "sprockets", "~> 3.0"
 
 group :development, :test do
   gem "pry-byebug"

--- a/lib/gakubuchi/engine_registrar.rb
+++ b/lib/gakubuchi/engine_registrar.rb
@@ -8,7 +8,10 @@ module Gakubuchi
       klass = constantize(engine)
       return false if !klass.instance_of?(::Class) || registered?(target)
 
-      @env.register_engine(target, klass)
+      args = [target, klass]
+      args << { silence_deprecation: true } if Sprockets::VERSION.start_with?("3")
+
+      @env.register_engine(*args)
       true
     end
 

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -16,6 +16,9 @@ Dummy::Application.configure do
   config.serve_static_files   = true
   config.static_cache_control = 'public, max-age=3600'
 
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
+
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/spec/lib/gakubuchi/engine_registrar_spec.rb
+++ b/spec/lib/gakubuchi/engine_registrar_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe Gakubuchi::EngineRegistrar do
     end
 
     context "when specified target is already registered" do
-      let(:target) { :coffee }
-      let(:engine) { "Sprockets::ERBProcessor" }
+      let(:target) { :sass }
+      let(:engine) { "Sprockets::SassTemplate" }
 
       describe "env.engines" do
         subject { -> { env.engines } }
@@ -39,11 +39,11 @@ RSpec.describe Gakubuchi::EngineRegistrar do
 
     context "when specified target is not registered" do
       let(:target) { :foo }
-      let(:engine) { "Sprockets::ERBProcessor" }
+      let(:engine) { "Sprockets::SassTemplate" }
 
       describe "env.engines" do
         subject { -> { env.engines } }
-        let(:expectation) { a_hash_including(".foo" => Sprockets::ERBProcessor) }
+        let(:expectation) { a_hash_including(".foo" => Sprockets::SassTemplate) }
 
         it { expect(&described_method).to change(&subject).to(expectation) }
       end


### PR DESCRIPTION
[NOTE] Related to #7.

# Description
Currently, gakubuchi uses `ActionView::Base#asset_digest_path` to resolve a digest path of `Template`.
However It causes the following bugs:

* Not copying templates to `public` when setting `config.assets.compile` to `false`
* Raising "No such file" error when the former manifest file exists (#7)

As I looked over Sprockets code, I found it was possible to solve the bugs 
by re-generating `Sprockets::Environment` just before executing gakubuchi's task.
This PR fixes it.

# Changes
## main
* Disable assets fallback to run specs in production like environment
* Fix `Gakubuchi::Template#digest_path` with `Sprockets::(Cached)Environment`

## addtional
* Disable deprecation warnings when using `register_engine` method in Sprockets 3
* Fix Appraisal settings to run specs with Sprockets 2