### PR TITLE
Fix errors and warnings when running specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 rvm:
   - 2.0
   - 2.1.9
-  - 2.2.5
-  - 2.3.1
+  - 2.2.6
+  - 2.3.3
 gemfile:
   - gemfiles/sprockets_rails_2_with_sprockets_2.gemfile
   - gemfiles/sprockets_rails_2_with_sprockets_3.gemfile

--- a/gakubuchi.gemspec
+++ b/gakubuchi.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "ammeter", ">= 1.0.0"
   s.add_development_dependency "appraisal", ">= 2.0.0"
-  s.add_development_dependency "codeclimate-test-reporter"
+  s.add_development_dependency "codeclimate-test-reporter", "~> 1.0"
   s.add_development_dependency "haml-rails"
   s.add_development_dependency "reek", "< 4.0.0"
   s.add_development_dependency "rspec-rails", ">= 3.0.1"

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -13,8 +13,14 @@ Dummy::Application.configure do
   config.eager_load = false
 
   # Configure static file server for tests with Cache-Control for performance.
-  config.serve_static_files   = true
-  config.static_cache_control = 'public, max-age=3600'
+  case Rails::VERSION::MAJOR
+  when 4
+    config.serve_static_files   = true
+    config.static_cache_control = 'public, max-age=3600'
+  when 5
+    config.public_file_server.enabled = true
+    config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
+  end
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,15 +2,9 @@
 ENV['RAILS_ENV'] ||= 'test'
 
 require 'simplecov'
-require 'codeclimate-test-reporter'
 
 SimpleCov.start do
   add_filter '/spec/'
-
-  formatter SimpleCov::Formatter::MultiFormatter.new([
-    SimpleCov::Formatter::HTMLFormatter,
-    CodeClimate::TestReporter::Formatter
-  ])
 end
 
 require File.expand_path('../dummy/config/environment', __FILE__)


### PR DESCRIPTION
# Description
This PR fixes the following errors and warnings.

## Formatter CodeClimate::TestReporter::Formatter failed
You can find it in a test log after running specs:

```
Formatter CodeClimate::TestReporter::Formatter failed with CodeClimate::TestReporter::Formatter::InvalidSimpleCovResultError: undefined method `values' for #<SimpleCov::Result:0x0000001af9fa28> (/home/travis/.rvm/gems/ruby-2.3.1/gems/codeclimate-test-reporter-1.0.3/lib/code_climate/test_reporter/formatter.rb:21:in `rescue in format')
```
ref. https://travis-ci.org/yasaichi/gakubuchi/jobs/178228543#L349

As I looked over it, I found it is caused because [ruby-test-reporter](https://github.com/codeclimate/ruby-test-reporter) v1 (released just 2 weeks ago) had some breaking changes.
Therefore, I specified the version and removed some lines related with the formatters.

## DEPRECATION WARNING(s) by Rails v5.0
You can find them in a test log before running specs:

```
DEPRECATION WARNING: `config.serve_static_files` is deprecated and will be removed in Rails 5.1.
Please use `config.public_file_server.enabled = true` instead.
 (called from block in <top (required)> at /home/travis/build/yasaichi/gakubuchi/spec/dummy/config/environments/test.rb:16)
DEPRECATION WARNING: `config.static_cache_control` is deprecated and will be removed in Rails 5.1.
Please use
`config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }`
instead.
 (called from block in <top (required)> at /home/travis/build/yasaichi/gakubuchi/spec/dummy/config/environments/test.rb:17)
```
ref. https://travis-ci.org/yasaichi/gakubuchi/jobs/178228543#L270-L277

## Additional changes
Recently, since Ruby 2.2.6 and 2.3.3 were released, I upgraded Ruby versions used for testing.