### PR TITLE
Add localized templates support

### DIFF
--- a/lib/gakubuchi/template.rb
+++ b/lib/gakubuchi/template.rb
@@ -68,7 +68,8 @@ module Gakubuchi
 
     def extract_extname(path)
       extname = path.extname
-      extname.empty? ? extname : "#{extract_extname(path.basename(extname))}#{extname}"
+      extname.empty? || extname == ".html" ?
+        extname : "#{extract_extname(path.basename(extname))}#{extname}"
     end
   end
 end

--- a/spec/dummy/app/assets/templates/corge.ja.html.erb
+++ b/spec/dummy/app/assets/templates/corge.ja.html.erb
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>corge.ja.html.erb</title>
+  <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
+  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+</head>
+<body>
+corge.ja.html.erb
+</body>
+</html>

--- a/spec/lib/gakubuchi/template_spec.rb
+++ b/spec/lib/gakubuchi/template_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Gakubuchi::Template do
         described_class.new("foo.html.erb"),
         described_class.new("bar/baz.html.erb"),
         described_class.new("qux.html.haml"),
-        described_class.new("quux.html.slim")
+        described_class.new("quux.html.slim"),
+        described_class.new("corge.ja.html.erb")
       ]
     end
 

--- a/spec/lib/gakubuchi/template_spec.rb
+++ b/spec/lib/gakubuchi/template_spec.rb
@@ -83,9 +83,18 @@ RSpec.describe Gakubuchi::Template do
 
   describe "#destination_path" do
     subject { template.destination_path }
-    let(:source_path) { "bar/baz.html.erb" }
 
-    it { is_expected.to eq Rails.public_path.join("bar/baz.html") }
+    context "when source path refers to a non-localized template file" do
+      let(:source_path) { "bar/baz.html.erb" }
+
+      it { is_expected.to eq Rails.public_path.join("bar/baz.html") }
+    end
+
+    context "when source path refers to a localized template file" do
+      let(:source_path) { "corge.ja.html.erb" }
+
+      it { is_expected.to eq Rails.public_path.join("corge.ja.html") }
+    end
   end
 
   describe "#digest_path" do
@@ -97,26 +106,54 @@ RSpec.describe Gakubuchi::Template do
     end
 
     context "when template exists in specified source path" do
-      let(:source_path) { "bar/baz.html.erb" }
-      let(:expectation) { Rails.public_path.join("assets", "bar/baz-[a-z0-9]*.html").to_s }
+      context "when source path refers to a non-localized template file" do
+        let(:source_path) { "bar/baz.html.erb" }
+        let(:expectation) { Rails.public_path.join("assets", "bar/baz-[a-z0-9]*.html").to_s }
 
-      it { is_expected.to be_an_instance_of Pathname }
-      it { is_expected.to be_fnmatch(expectation) }
+        it { is_expected.to be_an_instance_of Pathname }
+        it { is_expected.to be_fnmatch(expectation) }
+      end
+
+      context "when source path refers to a localized template file" do
+        let(:source_path) { "corge.ja.html.erb" }
+        let(:expectation) { Rails.public_path.join("assets", "corge.ja-[a-z0-9]*.html").to_s }
+
+        it { is_expected.to be_an_instance_of Pathname }
+        it { is_expected.to be_fnmatch(expectation) }
+      end
     end
   end
 
   describe "#extnanme" do
     subject { template.extname }
-    let(:source_path) { "foo.html.erb" }
 
-    it { is_expected.to eq ".html.erb" }
+    context "when source path refers to a non-localized template file" do
+      let(:source_path) { "foo.html.erb" }
+
+      it { is_expected.to eq ".html.erb" }
+    end
+
+    context "when source path refers to a localized template file" do
+      let(:source_path) { "corge.ja.html.erb" }
+
+      it { is_expected.to eq ".html.erb" }
+    end
   end
 
   describe "#logical_path" do
     subject { template.logical_path }
-    let(:source_path) { "bar/baz.html.erb" }
 
-    it { is_expected.to eq Pathname.new("bar/baz.html") }
+    context "when source path refers to a non-localized template file" do
+      let(:source_path) { "bar/baz.html.erb" }
+
+      it { is_expected.to eq Pathname.new("bar/baz.html") }
+    end
+
+    context "when source path refers to a localized template file" do
+      let(:source_path) { "corge.ja.html.erb" }
+
+      it { is_expected.to eq Pathname.new("corge.ja.html") }
+    end
   end
 
   describe "#source_path" do

--- a/spec/lib/tasks/after_precompile_spec.rb
+++ b/spec/lib/tasks/after_precompile_spec.rb
@@ -13,7 +13,8 @@ describe "rake assets:precompile" do
         Rails.public_path.join("foo.html"),
         Rails.public_path.join("bar/baz.html"),
         Rails.public_path.join("qux.html"),
-        Rails.public_path.join("quux.html")
+        Rails.public_path.join("quux.html"),
+        Rails.public_path.join("corge.ja.html")
       ]
     end
 


### PR DESCRIPTION
# Problem
ローカライズされたエラーページをgakubuchiで生成しようと以下の構造にしたところ、assets:precompile の結果、public以下にコピーされませんでした。
```
./app/assets/template
     \404.ja.html.slim
     \404.en.html.slim
```
なお、各エラーページはpublic/assets以下にコンパイルされています。
- public/assets/404.en-xxxx.html
- public/assets/404.ja-xxxx.html

この問題を修正するためのPullRequestです。
ご確認、ご検討お願いします。

## Error logs

```
> hilohiro@docker-sample:\~/proj/sample$ bin/rails assets:precompile
I, [2017-01-25T14:25:20.083882 #32738]  INFO -- : Writing /home/hilohiro/proj/sample/public/assets/apple-touch-icon-precomposed-d410df658e37fbd3eb2ff0c14cd27712c37b043c0316c45140ee6ebac95c8e8c.png
I, [2017-01-25T14:25:20.085468 #32738]  INFO -- : Writing /home/hilohiro/proj/sample/public/assets/apple-touch-icon-d410df658e37fbd3eb2ff0c14cd27712c37b043c0316c45140ee6ebac95c8e8c.png
I, [2017-01-25T14:25:20.095733 #32738]  INFO -- : Writing /home/hilohiro/proj/sample/public/assets/favicon-2667d2aebd1f37d0c28da43839de8691238f0c74ef332c3371e600a7ec3db2d1.ico
I, [2017-01-25T14:25:20.097190 #32738]  INFO -- : Writing /home/hilohiro/proj/sample/public/assets/favicon-2667d2aebd1f37d0c28da43839de8691238f0c74ef332c3371e600a7ec3db2d1.ico.gz
I, [2017-01-25T14:25:20.142257 #32738]  INFO -- : Writing /home/hilohiro/proj/sample/public/assets/application-4586df2c9172aec6cc707426ba5f83f7a590a4aeac2fe816fa5023c32963f2f9.js
I, [2017-01-25T14:25:20.142386 #32738]  INFO -- : Writing /home/hilohiro/proj/sample/public/assets/application-4586df2c9172aec6cc707426ba5f83f7a590a4aeac2fe816fa5023c32963f2f9.js.gz
I, [2017-01-25T14:25:20.146235 #32738]  INFO -- : Writing /home/hilohiro/proj/sample/public/assets/application-e1f6ae922b21b1148638ad9098d947d4621c2a3f78d910c2edb564763fffba0a.css
I, [2017-01-25T14:25:20.146367 #32738]  INFO -- : Writing /home/hilohiro/proj/sample/public/assets/application-e1f6ae922b21b1148638ad9098d947d4621c2a3f78d910c2edb564763fffba0a.css.gz
I, [2017-01-25T14:25:20.150458 #32738]  INFO -- : Writing /home/hilohiro/proj/sample/public/assets/404.en-7daffc54d903e450e5043a595ca8b173a67bd15e89fcfff9085a7e50181e2f38.html
I, [2017-01-25T14:25:20.150606 #32738]  INFO -- : Writing /home/hilohiro/proj/sample/public/assets/404.en-7daffc54d903e450e5043a595ca8b173a67bd15e89fcfff9085a7e50181e2f38.html.gz
I, [2017-01-25T14:25:20.151683 #32738]  INFO -- : Writing /home/hilohiro/proj/sample/public/assets/application-e1f6ae922b21b1148638ad9098d947d4621c2a3f78d910c2edb564763fffba0a.css.gz
I, [2017-01-25T14:25:20.152564 #32738]  INFO -- : Writing /home/hilohiro/proj/sample/public/assets/application-4586df2c9172aec6cc707426ba5f83f7a590a4aeac2fe816fa5023c32963f2f9.js
I, [2017-01-25T14:25:20.152683 #32738]  INFO -- : Writing /home/hilohiro/proj/sample/public/assets/application-4586df2c9172aec6cc707426ba5f83f7a590a4aeac2fe816fa5023c32963f2f9.js.gz
I, [2017-01-25T14:25:20.157230 #32738]  INFO -- : Writing /home/hilohiro/proj/sample/public/assets/404.ja-c06a533084c0bf1ef87b16e6855bdd291280b942bbb20eee0f24946e70ef0ec5.html
I, [2017-01-25T14:25:20.157366 #32738]  INFO -- : Writing /home/hilohiro/proj/sample/public/assets/404.ja-c06a533084c0bf1ef87b16e6855bdd291280b942bbb20eee0f24946e70ef0ec5.html.gz
I, [2017-01-25T14:25:20.157922 #32738]  INFO -- : Writing /home/hilohiro/proj/sample/public/assets/application-4586df2c9172aec6cc707426ba5f83f7a590a4aeac2fe816fa5023c32963f2f9.js
I, [2017-01-25T14:25:20.158023 #32738]  INFO -- : Writing /home/hilohiro/proj/sample/public/assets/application-4586df2c9172aec6cc707426ba5f83f7a590a4aeac2fe816fa5023c32963f2f9.js.gz
hilohiro@docker-sample:\~/proj/sample$ ls public/
assets  robots.txt
hilohiro@docker-sample:\~/proj/sample$
```
----
# Problem
When I tried to deal with localized templates by gakubuchi, they were precompiled but not copied to `/public`.
The directory and file structure is as follows:

```
./app/assets/template
     \404.ja.html.slim
     \404.en.html.slim
```

[NOTE] The compiled templates exist in `public/assets`
* public/assets/404.en-xxxx.html
* public/assets/404.ja-xxxx.html

This PR fixes that.
(translated by @yasaichi)


