### PR TITLE
Fix build failing on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,7 @@ matrix:
 branches:
   only:
     - master
+before_install:
+  - "gem update --system --no-doc"
 after_script:
   - '[ ${TRAVIS_EVENT_TYPE} != "pull_request" ] && [ ${TRAVIS_BRANCH} = "master" ] && bundle exec codeclimate-test-reporter'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,6 @@ branches:
     - master
 before_install:
   - "gem update --system --no-doc"
+  - "gem install bundler"
 after_script:
   - '[ ${TRAVIS_EVENT_TYPE} != "pull_request" ] && [ ${TRAVIS_BRANCH} = "master" ] && bundle exec codeclimate-test-reporter'

--- a/Appraisals
+++ b/Appraisals
@@ -2,12 +2,18 @@ appraise "sprockets-rails 2 with sprockets 2" do
   gem "railties", "~> 4.0"
   gem "sprockets-rails", "~> 2.0"
   gem "sprockets", "~> 2.0"
+
+  # NOTE: nokogiri dropped support for Ruby 2.0.0 on v1.7.0
+  gem "nokogiri", "< 1.7.0"
 end
 
 appraise "sprockets-rails 2 with sprockets 3" do
   gem "railties", "~> 4.0"
   gem "sprockets-rails", "~> 2.0"
   gem "sprockets", "~> 3.0"
+
+  # NOTE: nokogiri dropped support for Ruby 2.0.0 on v1.7.0
+  gem "nokogiri", "< 1.7.0"
 end
 
 appraise "sprockets-rails 3 with sprockets 3" do

--- a/gemfiles/sprockets_rails_2_with_sprockets_2.gemfile
+++ b/gemfiles/sprockets_rails_2_with_sprockets_2.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "railties", "~> 4.0"
 gem "sprockets-rails", "~> 2.0"
 gem "sprockets", "~> 2.0"
+gem "nokogiri", "< 1.7.0"
 
 group :development, :test do
   gem "pry-byebug"

--- a/gemfiles/sprockets_rails_2_with_sprockets_3.gemfile
+++ b/gemfiles/sprockets_rails_2_with_sprockets_3.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "railties", "~> 4.0"
 gem "sprockets-rails", "~> 2.0"
 gem "sprockets", "~> 3.0"
+gem "nokogiri", "< 1.7.0"
 
 group :development, :test do
   gem "pry-byebug"


### PR DESCRIPTION
[NOTE] Related to #11.

Currently, Travis build  is failing due to the following reasons:

* ["nokogiri requires Ruby version >= 2.1.0." when installing it on Ruby 2.0](https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#170--2016-12-26)
* ["can't modify frozen String" when installing rainbow gem on Ruby 2.3](https://github.com/sickill/rainbow/issues/49)

This PR fixes them.