### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ gem 'gakubuchi'
 Run the installation generator with:
 
 ```shell
-rails generate gakubuchi:install
+rails g gakubuchi:install
 ```
 
 Or specify the name of directory for static pages:
 
 ```shell
-rails generate gakubuchi:install -d html
+rails g gakubuchi:install -d html
 ```
 
 They will install the initializer into `config/initializers/gakubuchi.rb` and create the directory in `app/assets`.  
@@ -57,7 +57,7 @@ http://localhost:3000/assets/404.html
 Compile the templeate with:
 
 ```shell
-rake assets:precompile
+rails assets:precompile
 ```
 
 This will generate `public/404.html`.
@@ -111,9 +111,9 @@ You should follow the steps below.
 
 1. [Fork the repository](https://help.github.com/articles/fork-a-repo/)
 2. Create a feature branch: `git checkout -b add-new-feature`
-3. Commit your changes: `git commit -am 'add new feature'`
+3. Commit your changes: `git commit -am 'Add new feature'`
 4. Push the branch: `git push origin add-new-feature`
-4. [Send us a pull request](https://help.github.com/articles/using-pull-requests/)
+4. [Send us a pull request](https://help.github.com/articles/about-pull-requests/)
 
 We use [Appraisal](https://github.com/thoughtbot/appraisal) to test with different combinations of
 [sprockets](https://github.com/rails/sprockets) and [sprockets-rails](https://github.com/rails/sprockets-rails).

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "gakubuchi"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+require "pry"
+Pry.start

--- a/lib/gakubuchi.rb
+++ b/lib/gakubuchi.rb
@@ -10,21 +10,3 @@ if defined?(::Rails::Railtie) && defined?(::Sprockets::Railtie)
   require "gakubuchi/railtie"
   require "gakubuchi/template"
 end
-
-module Gakubuchi
-  class << self
-    attr_writer :configuration
-
-    def configuration
-      @configuration ||= ::Gakubuchi::Configuration.new
-    end
-
-    def configure
-      yield(configuration) if block_given?
-    end
-
-    def reset
-      @configuration = nil
-    end
-  end
-end

--- a/lib/gakubuchi.rb
+++ b/lib/gakubuchi.rb
@@ -1,12 +1,4 @@
 require "gakubuchi/configuration"
-require "gakubuchi/error"
-require "gakubuchi/fileutils"
-require "gakubuchi/mime_type"
+require "gakubuchi/railtie"
 require "gakubuchi/task"
 require "gakubuchi/version"
-
-if defined?(::Rails::Railtie) && defined?(::Sprockets::Railtie)
-  require "gakubuchi/engine_registrar"
-  require "gakubuchi/railtie"
-  require "gakubuchi/template"
-end

--- a/lib/gakubuchi.rb
+++ b/lib/gakubuchi.rb
@@ -22,7 +22,7 @@ module Gakubuchi
     attr_writer :configuration
 
     def configuration
-      @configuration ||= Configuration.new
+      @configuration ||= ::Gakubuchi::Configuration.new
     end
 
     def configure

--- a/lib/gakubuchi.rb
+++ b/lib/gakubuchi.rb
@@ -1,8 +1,3 @@
-require "fileutils"
-require "forwardable"
-require "logger"
-require "active_support/configurable"
-
 require "gakubuchi/configuration"
 require "gakubuchi/error"
 require "gakubuchi/fileutils"
@@ -11,10 +6,9 @@ require "gakubuchi/task"
 require "gakubuchi/version"
 
 if defined?(::Rails::Railtie) && defined?(::Sprockets::Railtie)
-  require "pathname"
   require "gakubuchi/engine_registrar"
-  require "gakubuchi/template"
   require "gakubuchi/railtie"
+  require "gakubuchi/template"
 end
 
 module Gakubuchi

--- a/lib/gakubuchi.rb
+++ b/lib/gakubuchi.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "gakubuchi/configuration"
 require "gakubuchi/railtie"
 require "gakubuchi/task"

--- a/lib/gakubuchi/configuration.rb
+++ b/lib/gakubuchi/configuration.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support/configurable"
 require "forwardable"
 

--- a/lib/gakubuchi/configuration.rb
+++ b/lib/gakubuchi/configuration.rb
@@ -1,3 +1,6 @@
+require "active_support/configurable"
+require "forwardable"
+
 module Gakubuchi
   class Configuration
     extend ::Forwardable

--- a/lib/gakubuchi/configuration.rb
+++ b/lib/gakubuchi/configuration.rb
@@ -2,6 +2,22 @@ require "active_support/configurable"
 require "forwardable"
 
 module Gakubuchi
+  class << self
+    attr_writer :configuration
+
+    def configuration
+      @configuration ||= ::Gakubuchi::Configuration.new
+    end
+
+    def configure
+      yield(configuration) if block_given?
+    end
+
+    def reset
+      @configuration = nil
+    end
+  end
+
   class Configuration
     extend ::Forwardable
     include ::ActiveSupport::Configurable

--- a/lib/gakubuchi/engine_registrar.rb
+++ b/lib/gakubuchi/engine_registrar.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "active_support/inflector"
 require "grease"
 require "sprockets"

--- a/lib/gakubuchi/error.rb
+++ b/lib/gakubuchi/error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Gakubuchi
   class Error < ::StandardError
     InvalidTemplate = ::Class.new(self)

--- a/lib/gakubuchi/error.rb
+++ b/lib/gakubuchi/error.rb
@@ -1,6 +1,6 @@
 module Gakubuchi
-  class Error < StandardError
-    InvalidTemplate = Class.new(self)
-    InvalidMimeType = Class.new(self)
+  class Error < ::StandardError
+    InvalidTemplate = ::Class.new(self)
+    InvalidMimeType = ::Class.new(self)
   end
 end

--- a/lib/gakubuchi/fileutils.rb
+++ b/lib/gakubuchi/fileutils.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "fileutils"
 require "logger"
 

--- a/lib/gakubuchi/fileutils.rb
+++ b/lib/gakubuchi/fileutils.rb
@@ -1,3 +1,6 @@
+require "fileutils"
+require "logger"
+
 module Gakubuchi
   module FileUtils
     extend ::FileUtils

--- a/lib/gakubuchi/mime_type.rb
+++ b/lib/gakubuchi/mime_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "gakubuchi/error"
 require "set"
 

--- a/lib/gakubuchi/railtie.rb
+++ b/lib/gakubuchi/railtie.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "gakubuchi/engine_registrar"
 require "gakubuchi/mime_type"
 require "gakubuchi/template"

--- a/lib/gakubuchi/railtie.rb
+++ b/lib/gakubuchi/railtie.rb
@@ -1,3 +1,8 @@
+require "gakubuchi/engine_registrar"
+require "gakubuchi/mime_type"
+require "gakubuchi/template"
+require "rails/railtie"
+
 module Gakubuchi
   class Railtie < ::Rails::Railtie
     config.assets.configure do |env|

--- a/lib/gakubuchi/railtie.rb
+++ b/lib/gakubuchi/railtie.rb
@@ -2,6 +2,7 @@ require "gakubuchi/engine_registrar"
 require "gakubuchi/mime_type"
 require "gakubuchi/template"
 require "rails/railtie"
+require "sprockets/railtie"
 
 module Gakubuchi
   class Railtie < ::Rails::Railtie

--- a/lib/gakubuchi/railtie.rb
+++ b/lib/gakubuchi/railtie.rb
@@ -1,7 +1,7 @@
 module Gakubuchi
   class Railtie < ::Rails::Railtie
     config.assets.configure do |env|
-      engine_registrar = EngineRegistrar.new(env)
+      engine_registrar = ::Gakubuchi::EngineRegistrar.new(env)
 
       haml = ::Gakubuchi::MimeType.new("text/haml", extensions: %w(.haml .html.haml))
       engine_registrar.register(haml, "Tilt::HamlTemplate")

--- a/lib/gakubuchi/task.rb
+++ b/lib/gakubuchi/task.rb
@@ -1,3 +1,4 @@
+require "gakubuchi/configuration"
 require "gakubuchi/fileutils"
 
 module Gakubuchi

--- a/lib/gakubuchi/task.rb
+++ b/lib/gakubuchi/task.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "gakubuchi/configuration"
 require "gakubuchi/fileutils"
 

--- a/lib/gakubuchi/task.rb
+++ b/lib/gakubuchi/task.rb
@@ -1,3 +1,5 @@
+require "gakubuchi/fileutils"
+
 module Gakubuchi
   class Task
     attr_reader :templates

--- a/lib/gakubuchi/task.rb
+++ b/lib/gakubuchi/task.rb
@@ -12,9 +12,11 @@ module Gakubuchi
         next if src.nil?
 
         dest = template.destination_path
-        FileUtils.copy_p(src, dest)
+        ::Gakubuchi::FileUtils.copy_p(src, dest)
 
-        FileUtils.remove([src, *::Dir.glob("#{src}.gz")]) unless leave_digest_named_templates?
+        unless leave_digest_named_templates?
+          ::Gakubuchi::FileUtils.remove([src, *::Dir.glob("#{src}.gz")])
+        end
       end
     end
 

--- a/lib/gakubuchi/template.rb
+++ b/lib/gakubuchi/template.rb
@@ -28,9 +28,9 @@ module Gakubuchi
 
       case
       when !@extname.include?("html")
-        fail Error::InvalidTemplate, "source path must refer to a template file"
+        raise ::Gakubuchi::Error::InvalidTemplate, "source path must refer to a template file"
       when !@source_path.fnmatch?(root.join("*").to_s)
-        fail Error::InvalidTemplate, "template must exist in #{root}"
+        raise ::Gakubuchi::Error::InvalidTemplate, "template must exist in #{root}"
       end
     end
 

--- a/lib/gakubuchi/template.rb
+++ b/lib/gakubuchi/template.rb
@@ -1,3 +1,9 @@
+require "forwardable"
+require "gakubuchi/error"
+require "pathname"
+require "rails"
+require "sprockets/railtie"
+
 module Gakubuchi
   class Template
     extend ::Forwardable

--- a/lib/gakubuchi/template.rb
+++ b/lib/gakubuchi/template.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "forwardable"
 require "gakubuchi/configuration"
 require "gakubuchi/error"

--- a/lib/gakubuchi/template.rb
+++ b/lib/gakubuchi/template.rb
@@ -1,4 +1,5 @@
 require "forwardable"
+require "gakubuchi/configuration"
 require "gakubuchi/error"
 require "pathname"
 require "rails"

--- a/lib/generators/gakubuchi/install/install_generator.rb
+++ b/lib/generators/gakubuchi/install/install_generator.rb
@@ -1,3 +1,7 @@
+require "gakubuchi/configuration"
+require "pathname"
+require "rails/generators/base"
+
 module Gakubuchi
   module Generators
     class InstallGenerator < ::Rails::Generators::Base

--- a/lib/generators/gakubuchi/install/install_generator.rb
+++ b/lib/generators/gakubuchi/install/install_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "gakubuchi/configuration"
 require "pathname"
 require "rails/generators/base"

--- a/lib/tasks/after_precompile.rake
+++ b/lib/tasks/after_precompile.rake
@@ -1,3 +1,6 @@
+require "gakubuchi/task"
+require "gakubuchi/template"
+
 Rake::Task["assets:precompile"].enhance do
   task = Gakubuchi::Task.new(Gakubuchi::Template.all)
   task.execute!

--- a/lib/tasks/after_precompile.rake
+++ b/lib/tasks/after_precompile.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "gakubuchi/task"
 require "gakubuchi/template"
 

--- a/spec/dummy/app/assets/templates/quux.html.slim
+++ b/spec/dummy/app/assets/templates/quux.html.slim
@@ -2,8 +2,8 @@ doctype html
 html
   head
     title
-      | quux.html.erb
+      | quux.html.slim
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true
     = javascript_include_tag 'application', 'data-turbolinks-track' => true
   body
-    | quux.html.erb
+    | quux.html.slim

--- a/spec/dummy/app/assets/templates/quuz.ja.html.erb
+++ b/spec/dummy/app/assets/templates/quuz.ja.html.erb
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>corge.ja.html.erb</title>
+  <title>quuz.ja.html.erb</title>
   <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
 </head>
 <body>
-corge.ja.html.erb
+quuz.ja.html.erb
 </body>
 </html>

--- a/spec/dummy/app/assets/templates/qux.html.haml
+++ b/spec/dummy/app/assets/templates/qux.html.haml
@@ -2,8 +2,8 @@
 %html
   %head
     %meta{content: 'text/html; charset=UTF-8', 'http-equiv' => 'Content-Type'}/
-    %title qux.html.erb
+    %title qux.html.haml
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true
     = javascript_include_tag 'application', 'data-turbolinks-track' => true
   %body
-    qux.html.erb
+    qux.html.haml

--- a/spec/lib/gakubuchi/engine_registrar_spec.rb
+++ b/spec/lib/gakubuchi/engine_registrar_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Gakubuchi::EngineRegistrar do
     context "when specified engine is an uninitialized constant" do
       let(:content_type) { "application/csv+ruby" }
       let(:engine) { "Foo" }
-      let(:extensions) { %w(.rcsv .csv.ruby) }
+      let(:extensions) { %w(.rcsv .csv.rcsv) }
 
       it "should return false" do
         expect(described_method.call).to eq false
@@ -43,7 +43,7 @@ RSpec.describe Gakubuchi::EngineRegistrar do
     context "when all parameters are valid" do
       let(:content_type) { "application/csv+ruby" }
       let(:engine) { Tilt::CSVTemplate }
-      let(:extensions) { %w(.rcsv .csv.ruby) }
+      let(:extensions) { %w(.rcsv .csv.rcsv) }
       let(:extensions_with_single_dot) { extensions.select { |ext| ext =~ /\A\.[^\.]+\z/ } }
 
       it "should return true" do

--- a/spec/lib/gakubuchi/engine_registrar_spec.rb
+++ b/spec/lib/gakubuchi/engine_registrar_spec.rb
@@ -21,7 +21,11 @@ RSpec.describe Gakubuchi::EngineRegistrar do
         expect(described_method.call).to eq false
       end
 
-      it "shouldn't register the engine for the MIME type" do
+      it "shouldn't register the MIME type with Sprockets::Environment" do
+        expect(&described_method).not_to change { env.mime_types }
+      end
+
+      it "shouldn't register the engine with Sprockets::Environment" do
         expect(&described_method).not_to change(&sprokcets_extensions)
       end
     end
@@ -35,7 +39,11 @@ RSpec.describe Gakubuchi::EngineRegistrar do
         expect(described_method.call).to eq false
       end
 
-      it "shouldn't register the engine for the MIME type" do
+      it "shouldn't register the MIME type with Sprockets::Environment" do
+        expect(&described_method).not_to change { env.mime_types }
+      end
+
+      it "shouldn't register the engine with Sprockets::Environment" do
         expect(&described_method).not_to change(&sprokcets_extensions)
       end
     end
@@ -50,7 +58,12 @@ RSpec.describe Gakubuchi::EngineRegistrar do
         expect(described_method.call).to eq true
       end
 
-      it "should register the engine for the MIME type" do
+      it "should register the MIME type with Sprockets::Environment", skip: major_version_of(Sprockets) < 4 do
+        diff = { mime_type.content_type => { extensions: mime_type.extensions } }
+        expect(&described_method).to change { env.mime_types }.to(hash_including(diff))
+      end
+
+      it "should register the engine with Sprockets::Environment" do
         diff =
           case major_version_of(Sprockets)
           when 2

--- a/spec/lib/gakubuchi/template_spec.rb
+++ b/spec/lib/gakubuchi/template_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Gakubuchi::Template do
         described_class.new("bar/baz.html.erb"),
         described_class.new("qux.html.haml"),
         described_class.new("quux.html.slim"),
-        described_class.new("corge.ja.html.erb")
+        described_class.new("quuz.ja.html.erb")
       ]
     end
 
@@ -86,14 +86,12 @@ RSpec.describe Gakubuchi::Template do
 
     context "when source path refers to a non-localized template file" do
       let(:source_path) { "bar/baz.html.erb" }
-
       it { is_expected.to eq Rails.public_path.join("bar/baz.html") }
     end
 
     context "when source path refers to a localized template file" do
-      let(:source_path) { "corge.ja.html.erb" }
-
-      it { is_expected.to eq Rails.public_path.join("corge.ja.html") }
+      let(:source_path) { "quuz.ja.html.erb" }
+      it { is_expected.to eq Rails.public_path.join("quuz.ja.html") }
     end
   end
 
@@ -115,8 +113,8 @@ RSpec.describe Gakubuchi::Template do
       end
 
       context "when source path refers to a localized template file" do
-        let(:source_path) { "corge.ja.html.erb" }
-        let(:expectation) { Rails.public_path.join("assets", "corge.ja-[a-z0-9]*.html").to_s }
+        let(:source_path) { "quuz.ja.html.erb" }
+        let(:expectation) { Rails.public_path.join("assets", "quuz.ja-[a-z0-9]*.html").to_s }
 
         it { is_expected.to be_an_instance_of Pathname }
         it { is_expected.to be_fnmatch(expectation) }
@@ -129,13 +127,11 @@ RSpec.describe Gakubuchi::Template do
 
     context "when source path refers to a non-localized template file" do
       let(:source_path) { "foo.html.erb" }
-
       it { is_expected.to eq ".html.erb" }
     end
 
     context "when source path refers to a localized template file" do
-      let(:source_path) { "corge.ja.html.erb" }
-
+      let(:source_path) { "quuz.ja.html.erb" }
       it { is_expected.to eq ".html.erb" }
     end
   end
@@ -145,14 +141,12 @@ RSpec.describe Gakubuchi::Template do
 
     context "when source path refers to a non-localized template file" do
       let(:source_path) { "bar/baz.html.erb" }
-
       it { is_expected.to eq Pathname.new("bar/baz.html") }
     end
 
     context "when source path refers to a localized template file" do
-      let(:source_path) { "corge.ja.html.erb" }
-
-      it { is_expected.to eq Pathname.new("corge.ja.html") }
+      let(:source_path) { "quuz.ja.html.erb" }
+      it { is_expected.to eq Pathname.new("quuz.ja.html") }
     end
   end
 

--- a/spec/lib/gakubuchi_spec.rb
+++ b/spec/lib/gakubuchi_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Gakubuchi do
     end
 
     before do
-      Gakubuchi.configure do |config|
+      described_class.configure do |config|
         config.leave_digest_named_templates = expected_attrs[:leave_digest_named_templates]
         config.template_directory = expected_attrs[:template_directory]
       end
@@ -26,7 +26,7 @@ RSpec.describe Gakubuchi do
     it { is_expected.to have_attributes(expected_attrs) }
 
     after do
-      Gakubuchi.reset
+      described_class.reset
     end
   end
 end

--- a/spec/lib/tasks/after_precompile_spec.rb
+++ b/spec/lib/tasks/after_precompile_spec.rb
@@ -14,7 +14,7 @@ describe "rake assets:precompile" do
         Rails.public_path.join("bar/baz.html"),
         Rails.public_path.join("qux.html"),
         Rails.public_path.join("quux.html"),
-        Rails.public_path.join("corge.ja.html")
+        Rails.public_path.join("quuz.ja.html")
       ]
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,7 +35,7 @@ Dir[File.expand_path("../../spec/support/**/*.rb", __FILE__)].each { |f| require
 # ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
-  # Include modules in all example groups
+  config.extend VersionHelpers
   config.include VersionHelpers
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
To release the v1.4.0, this PR adds the following minor fixes:

* README
    * For Rails 5
    * Fix links
* Specify a namespace of classes and modules
* Move `require` statements to appropriate places
* Fix specs
    * For consistency
    * Make the test cases closer to actual ones
    * Check changes on `env.mime_types`
* Enable frozen-string-literal for Ruby 3
* Add `bin/console` for better debugging
