### PR TITLE
Remove files in public directory after assets:clobber

### DIFF
--- a/lib/tasks/after_clobber.rake
+++ b/lib/tasks/after_clobber.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require "gakubuchi/template"
+require "gakubuchi/fileutils"
+
+Rake::Task["assets:clobber"].enhance do
+  destination_paths = Gakubuchi::Template.all.map(&:destination_path).select do |path|
+    File.exist?(path)
+  end
+  Gakubuchi::FileUtils.remove(destination_paths)
+end

--- a/spec/lib/tasks/after_clobber_spec.rb
+++ b/spec/lib/tasks/after_clobber_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+describe "rake assets:clobber" do
+  subject { Pathname.glob(Rails.public_path.join("**/*.html")) }
+
+  context "before `assets:precompile` is executed" do
+    before do
+      Rake::Task["assets:clobber"].execute
+    end
+
+    it { is_expected.to eq [] }
+  end
+
+  context "after `assets:precompile` is executed" do
+    before do
+      Rake::Task["assets:precompile"].execute
+      Rake::Task["assets:clobber"].execute
+    end
+
+    it { is_expected.to eq [] }
+  end
+
+  after do
+    FileUtils.rm_r(Dir.glob(Rails.public_path.join("*")), secure: true)
+  end
+end

--- a/spec/lib/tasks/after_precompile_spec.rb
+++ b/spec/lib/tasks/after_precompile_spec.rb
@@ -1,10 +1,6 @@
 require "rails_helper"
 
 describe "rake assets:precompile" do
-  before(:context) do
-    Rails.application.load_tasks
-  end
-
   describe "precompiled templates" do
     subject { Pathname.glob(Rails.public_path.join("**/*.html")) }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,6 +46,9 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
+  config.before(:suite) do
+    Rails.application.load_tasks
+  end
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.


### PR DESCRIPTION
This PR add a rake task to remove files in public directory after `rake assets:clobber` executed.
[NOTE] This task remove only files not empty directory.