### PR TITLE
Test the log messages output by Gakubuchi::Task

### DIFF
--- a/lib/gakubuchi/task.rb
+++ b/lib/gakubuchi/task.rb
@@ -41,7 +41,7 @@ module Gakubuchi
     end
 
     def logger
-      @logger ||= ::Logger.new(::STDOUT)
+      @logger ||= ::Logger.new($stdout)
     end
   end
 end

--- a/lib/tasks/after_clobber.rake
+++ b/lib/tasks/after_clobber.rake
@@ -3,7 +3,7 @@ require "fileutils"
 require "gakubuchi/template"
 
 Rake::Task["assets:clobber"].enhance do
-  logger = Logger.new(STDOUT)
+  logger = Logger.new($stdout)
   destination_paths = Gakubuchi::Template.all.map(&:destination_path)
 
   # TODO: Extract the followings as an instance method


### PR DESCRIPTION
This PR adds some test cases to check the log messages output by `Gakubuchi::Task`.