### PR TITLE
Fix build failure due to Bundler and RubyGems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ branches:
   only:
     - master
 before_install:
-  - "gem update --system --no-doc"
+  - gem update --system 2.7.9 --no-doc
   - "gem install bundler"
 after_script:
   - '[ ${TRAVIS_EVENT_TYPE} != "pull_request" ] && [ ${TRAVIS_BRANCH} = "master" ] && bundle exec codeclimate-test-reporter'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,6 @@ branches:
     - master
 before_install:
   - gem update --system 2.7.9 --no-doc
-  - "gem install bundler"
+  - gem install bundler -v '~> 1.0'
 after_script:
   - '[ ${TRAVIS_EVENT_TYPE} != "pull_request" ] && [ ${TRAVIS_BRANCH} = "master" ] && bundle exec codeclimate-test-reporter'


### PR DESCRIPTION
This PR fixes ...

* Bundler version to 1 because Rails 3 and 4 doesn't support Bundler v2.
* RubyGems version to 2 because its v3 drops support of Ruby 2.2 or former.
ref. https://github.com/rubygems/rubygems/blob/v3.0.0/rubygems-update.gemspec#L321