### PR TITLE
Fix build failure due to RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,7 @@
 inherit_from:
-  - https://raw.githubusercontent.com/rails/rails/master/.rubocop.yml
+  - https://raw.githubusercontent.com/rails/rails/5-2-stable/.rubocop.yml
 
 AllCops:
-  Rails:
-    Enabled: true
   Exclude:
     - gakubuchi.gemspec
     - spec/dummy/**/*
@@ -16,5 +14,6 @@ LineLength:
 Style/Documentation:
   Enabled: false
 
-Style/IndentationConsistency:
+Layout/IndentationConsistency:
+  Enabled: true
   EnforcedStyle: normal

--- a/gakubuchi.gemspec
+++ b/gakubuchi.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "reek"
   s.add_development_dependency "rspec-its"
   s.add_development_dependency "rspec-rails", ">= 3.0.1"
-  s.add_development_dependency "rubocop"
+  s.add_development_dependency "rubocop", "< 0.51.0"
   s.add_development_dependency "simplecov"
   # TODO: Deal with the bugs on the latest version of slim-rails
   s.add_development_dependency "slim-rails", "< 3.1.1"


### PR DESCRIPTION
This PR ...

* specifies the upper version of RoboCop to v0.51.0 because Ruby 2.0 hasn't been supported since the version.
* uses `.rubocop.yml` of Rails 5.2 because the master one uses a cop not supported in RuboCop v0.56 or former.