### PR TITLE
Deal with Ruby 2.2 in testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,13 @@ matrix:
       gemfile: gemfiles/sprockets_rails_3_with_sprockets_3.gemfile
     - rvm: 2.1.9
       gemfile: gemfiles/sprockets_rails_3_with_sprockets_3.gemfile
+    - rvm: 2.2.10
+      gemfile: gemfiles/sprockets_rails_3_with_sprockets_3.gemfile
     - rvm: 2.0
       gemfile: gemfiles/sprockets_rails_3_with_sprockets_4.gemfile
     - rvm: 2.1.9
+      gemfile: gemfiles/sprockets_rails_3_with_sprockets_4.gemfile
+    - rvm: 2.2.10
       gemfile: gemfiles/sprockets_rails_3_with_sprockets_4.gemfile
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: ruby
 sudo: false
 rvm:
   - 2.0
-  - 2.1.9
-  - 2.2.10
-  - 2.3.8
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
 gemfile:
   - gemfiles/sprockets_rails_2_with_sprockets_2.gemfile
   - gemfiles/sprockets_rails_2_with_sprockets_3.gemfile
@@ -15,25 +15,25 @@ gemfile:
   - gemfiles/sprockets_rails_3_with_sprockets_4.gemfile
 matrix:
   exclude:
-    - rvm: 2.5.5
+    - rvm: 2.5
       gemfile: gemfiles/sprockets_rails_2_with_sprockets_2.gemfile
-    - rvm: 2.6.3
+    - rvm: 2.6
       gemfile: gemfiles/sprockets_rails_2_with_sprockets_2.gemfile
-    - rvm: 2.5.5
+    - rvm: 2.5
       gemfile: gemfiles/sprockets_rails_2_with_sprockets_3.gemfile
-    - rvm: 2.6.3
+    - rvm: 2.6
       gemfile: gemfiles/sprockets_rails_2_with_sprockets_3.gemfile
     - rvm: 2.0
       gemfile: gemfiles/sprockets_rails_3_with_sprockets_3.gemfile
-    - rvm: 2.1.9
+    - rvm: 2.1
       gemfile: gemfiles/sprockets_rails_3_with_sprockets_3.gemfile
-    - rvm: 2.2.10
+    - rvm: 2.2
       gemfile: gemfiles/sprockets_rails_3_with_sprockets_3.gemfile
     - rvm: 2.0
       gemfile: gemfiles/sprockets_rails_3_with_sprockets_4.gemfile
-    - rvm: 2.1.9
+    - rvm: 2.1
       gemfile: gemfiles/sprockets_rails_3_with_sprockets_4.gemfile
-    - rvm: 2.2.10
+    - rvm: 2.2
       gemfile: gemfiles/sprockets_rails_3_with_sprockets_4.gemfile
 branches:
   only:


### PR DESCRIPTION
This PR skips running specs in Ruby 2.2 because Rails 5.2 or later uses Safe Navigation Operator (introduced in 2.3).